### PR TITLE
Optimize removing snapshots before undefining domains

### DIFF
--- a/devops/driver/libvirt/libvirt_driver.py
+++ b/devops/driver/libvirt/libvirt_driver.py
@@ -182,12 +182,16 @@ class DevopsDriver(object):
         self.conn.lookupByUUIDString(node.uuid).destroy()
 
     @retry()
-    def node_undefine(self, node):
+    def node_undefine(self, node, undefine_snapshots=False):
         """
         :type node: Node
             :rtype : None
         """
-        self.conn.lookupByUUIDString(node.uuid).undefine()
+        domain = self.conn.lookupByUUIDString(node.uuid)
+        if undefine_snapshots:
+            domain.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA)
+        else:
+            domain.undefine()
 
     @retry()
     def node_get_vnc_port(self, node):

--- a/devops/models.py
+++ b/devops/models.py
@@ -274,8 +274,7 @@ class Node(ExternalModel):
         if verbose or self.uuid:
             if verbose or self.driver.node_exists(self):
                 self.destroy(verbose=False)
-                self.driver.node_delete_all_snapshots(node=self)
-                self.driver.node_undefine(self)
+                self.driver.node_undefine(self, undefine_snapshots=True)
         self.delete()
 
     def suspend(self, verbose=False):


### PR DESCRIPTION
it increases performance of "erase" command. 

Use libvirt build-in function "undefineFlags" to delete snapshots along with undefining a domain.
