### PR TITLE
fix for running with django 1.5

### DIFF
--- a/devops/settings.py
+++ b/devops/settings.py
@@ -19,3 +19,6 @@ DATABASES = {
         'TEST_CHARSET': 'UTF8'
     }
 }
+
+SECRET_KEY = 'dummykey'
+


### PR DESCRIPTION
Django 1.5 Requires SECRET_KEY parameter to be set.
