### PR TITLE
Add support to change inteface model from virtio

### DIFF
--- a/devops/models.py
+++ b/devops/models.py
@@ -350,7 +350,7 @@ class Interface(models.Model):
     network = models.ForeignKey(Network)
     node = models.ForeignKey(Node)
     type = models.CharField(max_length=255, null=False)
-    model = choices('virtio')
+    model = choices('virtio', 'e1000', 'pcnet', 'rtl8139', 'ne2k_pci')
 
     @property
     def target_dev(self):

--- a/devops/tests/test_manager.py
+++ b/devops/tests/test_manager.py
@@ -37,6 +37,16 @@ class TestManager(TestCase):
         ip = network.next_ip()
         self.assertEquals('10.1.0.4', str(ip))
 
+    def test_network_model(self):
+        environment = manager.environment_create('test_env')
+        node = self.manager.node_create('test_node', environment)
+        network = self.manager.network_create(
+            environment=environment, name='internal', ip_network='10.1.0.0/24')
+        interface1 = self.manager.interface_create(network=network, node=node)
+        self.assertEquals('virtio', interface1.model)
+        interface2 = self.manager.interface_create(network=network, node=node, model='e1000')
+        self.assertEquals('e1000', interface2.model)
+
     def test_environment_values(self):
         environment = self.manager.environment_create('test_env')
         print environment.volumes


### PR DESCRIPTION
Add e1000, pcnet, rtl8139 to choices for model and test to ensure it updates.

This is needed to help with testing alternate drivers that sometimes need to
 be tested for errors.

Closes-bug #1257513
https://bugs.launchpad.net/fuel/+bug/1257513
